### PR TITLE
support everything but watcher on rails 4.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ rvm:
 gemfile:
  - gemfiles/rails32.gemfile
  - gemfiles/rails40.gemfile
+ - gemfiles/rails41.gemfile
 
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ gemfile:
  - gemfiles/rails32.gemfile
  - gemfiles/rails40.gemfile
  - gemfiles/rails41.gemfile
-
+ - gemfiles/rails42.gemfile
 
 matrix:
   exclude:

--- a/gemfiles/rails41.gemfile
+++ b/gemfiles/rails41.gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gemspec path: '../'
+
+gem "activerecord", "~> 4.1.0"

--- a/gemfiles/rails41.gemfile.lock
+++ b/gemfiles/rails41.gemfile.lock
@@ -1,0 +1,54 @@
+PATH
+  remote: ../
+  specs:
+    predictive_load (0.1.2)
+      activerecord (>= 3.2.0, < 4.2.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activemodel (4.1.13)
+      activesupport (= 4.1.13)
+      builder (~> 3.1)
+    activerecord (4.1.13)
+      activemodel (= 4.1.13)
+      activesupport (= 4.1.13)
+      arel (~> 5.0.0)
+    activesupport (4.1.13)
+      i18n (~> 0.6, >= 0.6.9)
+      json (~> 1.7, >= 1.7.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.1)
+      tzinfo (~> 1.1)
+    arel (5.0.1.20140414130214)
+    builder (3.2.2)
+    bump (0.5.2)
+    i18n (0.7.0)
+    json (1.8.3)
+    minitest (5.8.0)
+    minitest-rg (5.2.0)
+      minitest (~> 5.0)
+    query_diet (0.5.3)
+    rake (10.4.2)
+    sqlite3 (1.3.10)
+    thread_safe (0.3.5)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
+    wwtd (1.0.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  activerecord (~> 4.1.0)
+  bump
+  minitest
+  minitest-rg
+  predictive_load!
+  query_diet
+  rake
+  sqlite3
+  wwtd
+
+BUNDLED WITH
+   1.10.6

--- a/gemfiles/rails42.gemfile
+++ b/gemfiles/rails42.gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gemspec path: '../'
+
+gem "activerecord", "~> 4.1.0"

--- a/gemfiles/rails42.gemfile.lock
+++ b/gemfiles/rails42.gemfile.lock
@@ -1,0 +1,54 @@
+PATH
+  remote: ../
+  specs:
+    predictive_load (0.1.2)
+      activerecord (>= 3.2.0, < 4.3.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activemodel (4.1.13)
+      activesupport (= 4.1.13)
+      builder (~> 3.1)
+    activerecord (4.1.13)
+      activemodel (= 4.1.13)
+      activesupport (= 4.1.13)
+      arel (~> 5.0.0)
+    activesupport (4.1.13)
+      i18n (~> 0.6, >= 0.6.9)
+      json (~> 1.7, >= 1.7.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.1)
+      tzinfo (~> 1.1)
+    arel (5.0.1.20140414130214)
+    builder (3.2.2)
+    bump (0.5.2)
+    i18n (0.7.0)
+    json (1.8.3)
+    minitest (5.8.0)
+    minitest-rg (5.2.0)
+      minitest (~> 5.0)
+    query_diet (0.5.3)
+    rake (10.4.2)
+    sqlite3 (1.3.10)
+    thread_safe (0.3.5)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
+    wwtd (1.0.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  activerecord (~> 4.1.0)
+  bump
+  minitest
+  minitest-rg
+  predictive_load!
+  query_diet
+  rake
+  sqlite3
+  wwtd
+
+BUNDLED WITH
+   1.10.6

--- a/lib/predictive_load/loader.rb
+++ b/lib/predictive_load/loader.rb
@@ -27,6 +27,10 @@ module PredictiveLoad
       end
     end
 
+    protected
+
+    attr_reader :records
+
     def all_records_will_likely_load_association?(association_name)
       if defined?(Mocha) && association_name.to_s.index('_stub_')
         false
@@ -43,10 +47,6 @@ module PredictiveLoad
       end
       true
     end
-
-    protected
-
-    attr_reader :records
 
     def preload(association_name)
       ActiveRecord::Associations::Preloader.new(records_with_association(association_name), [ association_name ]).run

--- a/lib/predictive_load/loader.rb
+++ b/lib/predictive_load/loader.rb
@@ -49,7 +49,11 @@ module PredictiveLoad
     end
 
     def preload(association_name)
-      ActiveRecord::Associations::Preloader.new(records_with_association(association_name), [ association_name ]).run
+      if ActiveRecord::VERSION::STRING <= "4.1.0"
+        ActiveRecord::Associations::Preloader.new(records_with_association(association_name), [ association_name ]).run
+      else
+        ActiveRecord::Associations::Preloader.new.preload(records_with_association(association_name), [ association_name ])
+      end
     end
 
     def records_with_association(association_name)

--- a/lib/predictive_load/watcher.rb
+++ b/lib/predictive_load/watcher.rb
@@ -1,3 +1,5 @@
+raise "Not supported on rails 4.1+" if ActiveRecord::VERSION::STRING >= "4.1.0"
+
 require 'predictive_load/loader'
 require 'predictive_load/preload_log'
 

--- a/predictive_load.gemspec
+++ b/predictive_load.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |gem|
   gem.name          = "predictive_load"
   gem.version       = '0.1.2'
 
-  gem.add_runtime_dependency "activerecord", ">= 3.2.0", "< 4.1.0"
+  gem.add_runtime_dependency "activerecord", ">= 3.2.0", "< 4.2.0"
   gem.add_development_dependency "minitest"
   gem.add_development_dependency "minitest-rg"
   gem.add_development_dependency 'sqlite3'

--- a/predictive_load.gemspec
+++ b/predictive_load.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |gem|
   gem.name          = "predictive_load"
   gem.version       = '0.1.2'
 
-  gem.add_runtime_dependency "activerecord", ">= 3.2.0", "< 4.2.0"
+  gem.add_runtime_dependency "activerecord", ">= 3.2.0", "< 4.3.0"
   gem.add_development_dependency "minitest"
   gem.add_development_dependency "minitest-rg"
   gem.add_development_dependency 'sqlite3'

--- a/test/active_record_collection_observation_test.rb
+++ b/test/active_record_collection_observation_test.rb
@@ -1,4 +1,13 @@
 require_relative 'helper'
+
+if ActiveRecord::VERSION::STRING >= "4.1.0"
+  describe "PredictiveLoad::Watcher" do
+    it "does not work" do
+      skip "does not work"
+    end
+  end
+else
+
 require 'predictive_load/watcher'
 
 describe PredictiveLoad::ActiveRecordCollectionObservation do
@@ -41,4 +50,5 @@ describe PredictiveLoad::ActiveRecordCollectionObservation do
 
   end
 
+end
 end

--- a/test/loader_test.rb
+++ b/test/loader_test.rb
@@ -140,11 +140,19 @@ describe PredictiveLoad::Loader do
           end
         end
 
-        it "preloads when staticly scoped" do
-          skip "static scopes could be cached in rails 3 too, but they are not for some reason" if ActiveRecord::VERSION::MAJOR == 3
+        it "does not preload when staticly scoped" do
+          skip "this only caches on rails 4.0 ... and is removed in rails 4.1+" if ActiveRecord::VERSION::STRING >= "4.0.0"
           users = User.all.to_a
-          assert_queries(1) do
+          assert_queries(2) do
             users.each { |user| user.comments.recent.to_a }
+          end
+        end
+
+        it "does not preload when block scoped" do
+          skip "Unsupported syntax" if ActiveRecord::VERSION::MAJOR == 3
+          users = User.all.to_a
+          assert_queries(2) do
+            users.each { |user| user.comments.recent_v2.to_a }
           end
         end
 

--- a/test/models.rb
+++ b/test/models.rb
@@ -7,10 +7,12 @@ class User < ActiveRecord::Base
   def full_name
     name
   end
-
 end
 
 class Email < ActiveRecord::Base
+end
+
+class EmailsUser < ActiveRecord::Base
 end
 
 class Topic < ActiveRecord::Base
@@ -20,10 +22,11 @@ end
 class Comment < ActiveRecord::Base
   belongs_to :user
 
-
-  ActiveSupport::Deprecation.silence do
-    belongs_to :user_by_proc, :class_name => "User", :foreign_key => :user_id,
-      :conditions => proc { |object| "1 = #{ActiveRecord::VERSION::MAJOR == 3 ? one : object.one}" }
+  unless ActiveRecord::VERSION::STRING > "4.1.0"
+    ActiveSupport::Deprecation.silence do
+      belongs_to :user_by_proc, :class_name => "User", :foreign_key => :user_id,
+        :conditions => proc { |object| "1 = #{ActiveRecord::VERSION::MAJOR == 3 ? one : object.one}" }
+    end
   end
 
   if ActiveRecord::VERSION::MAJOR > 3

--- a/test/models.rb
+++ b/test/models.rb
@@ -20,8 +20,11 @@ end
 class Comment < ActiveRecord::Base
   belongs_to :user
 
-  belongs_to :user_by_proc, :class_name => "User", :foreign_key => :user_id,
-    :conditions => proc { |object| "1 = #{ActiveRecord::VERSION::MAJOR == 3 ? one : object.one}" }
+
+  ActiveSupport::Deprecation.silence do
+    belongs_to :user_by_proc, :class_name => "User", :foreign_key => :user_id,
+      :conditions => proc { |object| "1 = #{ActiveRecord::VERSION::MAJOR == 3 ? one : object.one}" }
+  end
 
   if ActiveRecord::VERSION::MAJOR > 3
     belongs_to :user_by_proc_v2,
@@ -37,7 +40,10 @@ class Comment < ActiveRecord::Base
   belongs_to :topic
 
   scope :by_topic, lambda { |topic| where(:topic_id => topic.id) }
-  scope :recent, order('updated_at desc')
+  ActiveSupport::Deprecation.silence do
+    scope :recent, order('updated_at desc')
+  end
+  scope :recent_v2, lambda { order('updated_at desc') }
 
   def one
     1

--- a/test/watcher_test.rb
+++ b/test/watcher_test.rb
@@ -1,4 +1,13 @@
 require_relative 'helper'
+
+if ActiveRecord::VERSION::STRING >= "4.1.0"
+  describe "PredictiveLoad::Watcher" do
+    it "does not work" do
+      skip "does not work"
+    end
+  end
+else
+
 require 'predictive_load/watcher'
 require 'logger'
 
@@ -63,7 +72,13 @@ predictive_load: would have prevented all 1 queries
       comments = Comment.all.to_a
       assert_equal 2, comments.size
       assert_queries(2) do
-        comments.each { |comment| assert comment.user_by_proc.full_name }
+        comments.each do |comment|
+          if ActiveRecord::VERSION::STRING < "4.1.0"
+            assert comment.user_by_proc.full_name
+          else
+            assert comment.user_by_proc_v2.full_name
+          end
+        end
       end
     end
   end
@@ -91,4 +106,6 @@ predictive_load: would have prevented all 1 queries
       logger.formatter = proc { |severity, datetime, progname, msg| "#{msg}\n" }
     end
   end
+end
+
 end


### PR DESCRIPTION
@pschambacher @eac @staugaard

watcher is super messy since the preloader got rewritten in 4.1 ... but we don't really need it, it's just a debugging tool ...