### PR TITLE
do not officially support static scopes ...

### DIFF
--- a/lib/predictive_load/loader.rb
+++ b/lib/predictive_load/loader.rb
@@ -27,6 +27,10 @@ module PredictiveLoad
       end
     end
 
+    protected
+
+    attr_reader :records
+
     def all_records_will_likely_load_association?(association_name)
       if defined?(Mocha) && association_name.to_s.index('_stub_')
         false
@@ -43,10 +47,6 @@ module PredictiveLoad
       end
       true
     end
-
-    protected
-
-    attr_reader :records
 
     def preload(association_name)
       ActiveRecord::Associations::Preloader.new(records_with_association(association_name), [ association_name ]).run

--- a/test/loader_test.rb
+++ b/test/loader_test.rb
@@ -140,11 +140,19 @@ describe PredictiveLoad::Loader do
           end
         end
 
-        it "preloads when staticly scoped" do
-          skip "static scopes could be cached in rails 3 too, but they are not for some reason" if ActiveRecord::VERSION::MAJOR == 3
+        it "does not preload when staticly scoped" do
+          skip "this only caches on rails 4.0 ... and is removed in rails 4.1+" if ActiveRecord::VERSION::STRING >= "4.0.0"
           users = User.all.to_a
-          assert_queries(1) do
+          assert_queries(2) do
             users.each { |user| user.comments.recent.to_a }
+          end
+        end
+
+        it "does not preload when block scoped" do
+          skip "Unsupported syntax" if ActiveRecord::VERSION::MAJOR == 3
+          users = User.all.to_a
+          assert_queries(2) do
+            users.each { |user| user.comments.recent_v2.to_a }
           end
         end
 

--- a/test/models.rb
+++ b/test/models.rb
@@ -20,8 +20,11 @@ end
 class Comment < ActiveRecord::Base
   belongs_to :user
 
-  belongs_to :user_by_proc, :class_name => "User", :foreign_key => :user_id,
-    :conditions => proc { |object| "1 = #{ActiveRecord::VERSION::MAJOR == 3 ? one : object.one}" }
+
+  ActiveSupport::Deprecation.silence do
+    belongs_to :user_by_proc, :class_name => "User", :foreign_key => :user_id,
+      :conditions => proc { |object| "1 = #{ActiveRecord::VERSION::MAJOR == 3 ? one : object.one}" }
+  end
 
   if ActiveRecord::VERSION::MAJOR > 3
     belongs_to :user_by_proc_v2,
@@ -37,7 +40,10 @@ class Comment < ActiveRecord::Base
   belongs_to :topic
 
   scope :by_topic, lambda { |topic| where(:topic_id => topic.id) }
-  scope :recent, order('updated_at desc')
+  ActiveSupport::Deprecation.silence do
+    scope :recent, order('updated_at desc')
+  end
+  scope :recent_v2, lambda { order('updated_at desc') }
 
   def one
     1


### PR DESCRIPTION
not sure what happens when they are cached, but it only works on rails 4.0 with deprecated scope syntax we are not using anyway ...
so ignore them ...

@pschambacher @eac @staugaard