### PR TITLE
fix unscoped vs eager load

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,3 +78,4 @@ would have prevented all 10 queries
 
 * Calling association#size will trigger an N+1 on SELECT COUNT(*). Work around by calling #length, loading all records.
 * Calling first / last will trigger an N+1.
+* Rails 4: unscoped will disable eager loading to circument a rails bug ... hopefully fixed in rails 5 https://github.com/rails/rails/pull/16531

--- a/lib/predictive_load/active_record_collection_observation.rb
+++ b/lib/predictive_load/active_record_collection_observation.rb
@@ -3,6 +3,7 @@ module PredictiveLoad::ActiveRecordCollectionObservation
   def self.included(base)
     ActiveRecord::Relation.send(:include, RelationObservation)
     ActiveRecord::Base.send(:include, CollectionMember)
+    ActiveRecord::Base.send(:extend, UnscopedTracker)
     ActiveRecord::Associations::Association.send(:include, AssociationNotification)
     ActiveRecord::Associations::CollectionAssociation.send(:include, CollectionAssociationNotification)
   end
@@ -30,6 +31,32 @@ module PredictiveLoad::ActiveRecordCollectionObservation
 
     attr_accessor :collection_observer
 
+  end
+
+  # disable eager loading since includes + unscoped is broken on rails 4
+  module UnscopedTracker
+    if ActiveRecord::VERSION::MAJOR == 4
+      def unscoped
+        if block_given?
+          begin
+            old, self.predictive_load_disabled = predictive_load_disabled, true
+            super
+          ensure
+            self.predictive_load_disabled = old
+          end
+        else
+          super
+        end
+      end
+    end
+
+    def predictive_load_disabled=(value)
+      Thread.current[:predictive_load_disabled] = value
+    end
+
+    def predictive_load_disabled
+      Thread.current[:predictive_load_disabled]
+    end
   end
 
   module AssociationNotification

--- a/lib/predictive_load/loader.rb
+++ b/lib/predictive_load/loader.rb
@@ -40,6 +40,7 @@ module PredictiveLoad
     end
 
     def supports_preload?(association)
+      return false if ActiveRecord::Base.predictive_load_disabled
       return false if association.reflection.options[:predictive_load] == false
       return false if association.reflection.options[:conditions].respond_to?(:to_proc) # rails 3 conditions proc (we do not know if it uses instance methods)
       if ActiveRecord::VERSION::MAJOR > 3

--- a/test/loader_test.rb
+++ b/test/loader_test.rb
@@ -136,6 +136,21 @@ describe PredictiveLoad::Loader do
         end
       end
 
+      it "preloads correctly when unscoped" do
+        # users each have a public and private comment, the private comment is excluded by the default scope
+        users = User.all.to_a
+        assert_equal 2, users.size
+        users.each { |u| Comment.create!(user: u, public: false, topic: Topic.first, body: "xx") }
+
+        # when eager loading inside of unscoped the private comment should show up
+        Comment.unscoped do
+          expected = (ActiveRecord::VERSION::MAJOR == 4 ? 2 : 1) # we disable preloading in unscoped blocks in rails 4 because it's broken ... maybe patch coming for 5 https://github.com/rails/rails/pull/16531
+          assert_queries(expected) do
+            users.each { |user| user.comments.to_a.map(&:public).uniq.must_equal [true, false] }
+          end
+        end
+      end
+
       describe "unsupported behavior" do
         it "does not preload when dynamically scoped" do
           users = User.all.to_a

--- a/test/models.rb
+++ b/test/models.rb
@@ -20,6 +20,7 @@ class Topic < ActiveRecord::Base
 end
 
 class Comment < ActiveRecord::Base
+  default_scope { where(public: true) }
   belongs_to :user
 
   unless ActiveRecord::VERSION::STRING > "4.1.0"

--- a/test/schema.rb
+++ b/test/schema.rb
@@ -33,6 +33,7 @@ ActiveRecord::Schema.define(:version => 1) do
     t.string   :body,     :null => false
     t.integer  :topic_id, :null => false
     t.integer  :user_id,  :null => false
+    t.boolean  :public,   :null => false, :default => true
     t.timestamps
   end
 

--- a/test/watcher_test.rb
+++ b/test/watcher_test.rb
@@ -36,14 +36,14 @@ describe PredictiveLoad::Watcher do
       users[1].id = 2
       message = "predictive_load: detected n1 call on User#comments
 predictive_load: expect to prevent 1 queries
-predictive_load: would preload with: SELECT \"comments\".* FROM \"comments\"  WHERE \"comments\".\"user_id\" IN (1, 2)
+predictive_load: would preload with: SELECT \"comments\".* FROM \"comments\"  WHERE \"comments\".\"public\" = 't' AND \"comments\".\"user_id\" IN (1, 2)
 predictive_load: 0|0|0|SCAN TABLE comments
 
 predictive_load: 0|0|0|EXECUTE LIST SUBQUERY 1
 
 predictive_load: would have prevented all 1 queries
 "
-      assert_log(message, /\d+\.\d+ms| \(~100000 rows\)/) do
+      assert_log(message, /\d+\.\d+ms| \(~10+ rows\)/) do
         users.each { |user| user.comments.to_a }
       end
     end


### PR DESCRIPTION
unscoped { includes } is broken in rails 4+
so we try to avoid this bug by disabling eager loading -> triggering less includes

maybe coming fix: https://github.com/rails/rails/pull/16531

@eac @pschambacher @staugaard @steved