### PR TITLE
fix redictive_load option not working in rails 3 when belongs_to was …

### DIFF
--- a/lib/predictive_load.rb
+++ b/lib/predictive_load.rb
@@ -1,4 +1,13 @@
 module PredictiveLoad
 end
 
-ActiveRecord::Associations::Builder::Association.valid_options << :predictive_load
+klasses = [ActiveRecord::Associations::Builder::Association]
+
+if ActiveRecord::VERSION::MAJOR == 3
+  # when belongs_to etc is loaded before us it already made a copy of valid_options
+  klasses.concat ActiveRecord::Associations::Builder::Association.descendants
+end
+
+klasses.each do |klass|
+  klass.valid_options << :predictive_load
+end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -2,6 +2,8 @@ require 'bundler/setup'
 require 'minitest/autorun'
 require 'minitest/rg'
 require 'active_record'
+require 'active_support/all'
+require 'active_record/associations/builder/belongs_to' # pretend we loaded this first to test initializer
 require 'predictive_load'
 require 'predictive_load/active_record_collection_observation'
 require 'query_diet/logger'


### PR DESCRIPTION
…used before predictive load

@pschambacher