### PR TITLE
support deprecated finders which has a options hash with the :conditi…

### DIFF
--- a/gemfiles/rails32.gemfile.lock
+++ b/gemfiles/rails32.gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: ../
   specs:
-    predictive_load (0.1.2)
-      activerecord (>= 3.2.0, < 4.1.0)
+    predictive_load (0.3.1)
+      activerecord (>= 3.2.0, < 4.3.0)
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/rails40.gemfile.lock
+++ b/gemfiles/rails40.gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: ../
   specs:
-    predictive_load (0.1.2)
-      activerecord (>= 3.2.0, < 4.1.0)
+    predictive_load (0.3.1)
+      activerecord (>= 3.2.0, < 4.3.0)
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/rails41.gemfile.lock
+++ b/gemfiles/rails41.gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: ../
   specs:
-    predictive_load (0.1.2)
-      activerecord (>= 3.2.0, < 4.2.0)
+    predictive_load (0.3.1)
+      activerecord (>= 3.2.0, < 4.3.0)
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/rails42.gemfile.lock
+++ b/gemfiles/rails42.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../
   specs:
-    predictive_load (0.1.2)
+    predictive_load (0.3.1)
       activerecord (>= 3.2.0, < 4.3.0)
 
 GEM

--- a/test/loader_test.rb
+++ b/test/loader_test.rb
@@ -42,6 +42,15 @@ describe PredictiveLoad::Loader do
         end
       end
 
+      it "preloads with static conditions" do
+        skip "Unsupported syntax" if ActiveRecord::VERSION::STRING > "4.1.0"
+        comments = Comment.all.to_a
+        assert_equal 2, comments.size
+        assert_queries(1) do
+          comments.each { |comment| assert comment.user_with_static_conditions.name }
+        end
+      end
+
       it "does not attempt to preload associations with proc conditions" do
         skip "Unsupported syntax" if ActiveRecord::VERSION::STRING > "4.1.0"
         comments = Comment.all.to_a

--- a/test/models.rb
+++ b/test/models.rb
@@ -25,8 +25,10 @@ class Comment < ActiveRecord::Base
 
   unless ActiveRecord::VERSION::STRING > "4.1.0"
     ActiveSupport::Deprecation.silence do
-      belongs_to :user_by_proc, :class_name => "User", :foreign_key => :user_id,
-        :conditions => proc { |object| "1 = #{ActiveRecord::VERSION::MAJOR == 3 ? one : object.one}" }
+      block = (ActiveRecord::VERSION::MAJOR == 3 ? proc { "1 = #{one}" } : proc { |object| "1 = #{object.one}" })
+      belongs_to :user_by_proc, :class_name => "User", :foreign_key => :user_id, :conditions => block
+
+      belongs_to :user_with_static_conditions, :class_name => "User", :foreign_key => :user_id, :conditions => "1 = 1"
     end
   end
 


### PR DESCRIPTION
…ons as :where

`has_many :attachments, conditions: 'xxx'` should not be cached, but 
`has_many :attachments, conditions: proc { |x| x.foo }` should be
arity of the scope is always 1 with rails 4.0 / deprecated finders, so we have to look a bit deeper

```
#<ActiveRecord::Associations::Builder::DeprecatedOptionsProc:0x007fe1687be368 
@options={:order=>"created_at ASC, id ASC", :where=>"parent_id IS NULL"}>
```

@pschambacher 